### PR TITLE
tracked export API; additional sensor types

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -256,8 +256,6 @@ only_rules:
   - redundant_nil_coalescing
   # Objective-C attribute (@objc) is redundant in declaration.
   - redundant_objc_attribute
-  # Initializing an optional variable with nil is redundant.
-  - redundant_optional_initialization
   # Property setter access level shouldn't be explicit if it's the same as the variable access level.
   - redundant_set_access_control
   # String enum values can be omitted when they are equal to the enumcase name.

--- a/Package.swift
+++ b/Package.swift
@@ -22,14 +22,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.2.0")
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.2.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.1")
     ] + swiftLintPackage(),
     targets: [
         .target(
             name: "SpeziSensorKit",
             dependencies: [
                 .product(name: "Spezi", package: "Spezi"),
-                .product(name: "SpeziFoundation", package: "SpeziFoundation")
+                .product(name: "SpeziFoundation", package: "SpeziFoundation"),
+                .product(name: "SpeziLocalStorage", package: "SpeziStorage")
             ],
             swiftSettings: [
                 .enableUpcomingFeature("ExistentialAny"),

--- a/Sources/SpeziSensorKit/BatchedAsyncDataFetcher.swift
+++ b/Sources/SpeziSensorKit/BatchedAsyncDataFetcher.swift
@@ -1,0 +1,103 @@
+//
+// This source file is part of the SpeziSensorKit open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+@preconcurrency import SensorKit
+
+
+/// An `AsyncSequence` and `AsyncIterator` that can be used to fetch and process data from SensorKit, split into distinct batches.
+///
+/// Each batch will be fetched from SensorKit on demand, i.e. when ``next(isolation:)`` is called.
+///
+/// - Important: Due to the lazy nature of this type, the sequence should only be iterated once.
+@available(iOS 18, *)
+struct BatchedAsyncDataFetcher<Sample, SensorReader: SensorReaderProtocol<Sample>>: AsyncSequence, AsyncIteratorProtocol {
+    typealias Element = [SensorKit.FetchResult<Sample>]
+    typealias Failure = any Error
+    typealias AsyncIterator = Self
+    
+    private enum State {
+        case initial
+        case process(timeRange: Range<Date>, devices: [SRDevice])
+        /// The data fetcher is done, i.e. has fetched (and returned) all data that is currently available.
+        case done
+    }
+    
+    private let reader: SensorReader
+    private let anchor: ManagedQueryAnchor
+    private var sensor: Sensor<Sample> {
+        reader.sensor
+    }
+    private let quarantineCutoff: Date
+    nonisolated(unsafe) private let devices: [SRDevice]
+    
+    private var state: State = .initial
+    
+    init(reader: SensorReader, anchor: ManagedQueryAnchor) async throws {
+        self.reader = reader
+        self.anchor = anchor
+        self.quarantineCutoff = reader.sensor.currentQuarantineBegin
+        self.devices = try await reader.fetchDevices()
+    }
+    
+    consuming func makeAsyncIterator() -> BatchedAsyncDataFetcher<Sample, SensorReader> {
+        self
+    }
+    
+    private mutating func advanceState() throws {
+        switch state {
+        case .done:
+            return
+        case .initial:
+            var currentAnchor = try anchor.value
+            guard currentAnchor.timestamp < quarantineCutoff else {
+                state = .done
+                return
+            }
+            if currentAnchor.timestamp == .distantPast {
+                // first time
+                currentAnchor = .init(timestamp: quarantineCutoff.addingTimeInterval(-Duration.days(7).timeInterval))
+                try anchor.update(currentAnchor)
+            }
+            let batchStartDate = currentAnchor.timestamp
+            let batchEndDate = Swift.min(batchStartDate.addingTimeInterval(sensor.suggestedBatchSize.timeInterval), quarantineCutoff)
+            state = .process(timeRange: batchStartDate..<batchEndDate, devices: devices)
+        case let .process(timeRange, devices):
+            guard devices.count <= 1 else {
+                state = .process(timeRange: timeRange, devices: Array(devices.dropFirst()))
+                return
+            }
+            try self.anchor.update(.init(timestamp: timeRange.upperBound))
+            guard timeRange.upperBound < quarantineCutoff else {
+                // we already were processing the last (currently available) batch
+                state = .done
+                return
+            }
+            let newStartDate = timeRange.upperBound
+            let newEndDate = Swift.min(newStartDate.addingTimeInterval(sensor.suggestedBatchSize.timeInterval), quarantineCutoff)
+            state = .process(timeRange: newStartDate..<newEndDate, devices: self.devices)
+        }
+    }
+    
+    mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> Element? {
+        switch state {
+        case .done:
+            return nil
+        case .initial:
+            try advanceState()
+            return try await next(isolation: actor)
+        case let .process(timeRange, devices):
+            guard let device = devices.first else {
+                try advanceState()
+                return try await next(isolation: actor)
+            }
+            let results = try await reader.fetch(from: device, timeRange: timeRange)
+            try advanceState()
+            return results
+        }
+    }
+}

--- a/Sources/SpeziSensorKit/QueryAnchor.swift
+++ b/Sources/SpeziSensorKit/QueryAnchor.swift
@@ -1,0 +1,66 @@
+//
+// This source file is part of the SpeziSensorKit open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable file_types_order
+
+import Foundation
+import SpeziLocalStorage
+
+
+/// Used to keep track of previously-fetched SensorKit samples to avoid duplicates when querying data.
+struct QueryAnchor: Hashable, Codable, Sendable {
+    /// The most-recent point in time for which data was queried.
+    ///
+    /// Note that this refers to the upper bound of the time range *for* which data was queried, not the point in time *at* which the query took place.
+    let timestamp: Date
+    
+    /// Creates a new, empty `QueryAnchor`.
+    init() {
+        self.timestamp = .distantPast
+    }
+    
+    /// Creates a new `QueryAnchor` for the specified timestamp.
+    init(timestamp: Date) {
+        self.timestamp = timestamp
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        timestamp = try container.decode(Date.self)
+    }
+    
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(timestamp)
+    }
+}
+
+
+/// A `QueryAnchor` that is backed using Spezi LocalStorage.
+final class ManagedQueryAnchor: Sendable {
+    private let get: @Sendable () throws -> QueryAnchor
+    private let set: @Sendable (QueryAnchor) throws -> Void
+    
+    var value: QueryAnchor {
+        get throws {
+            try get()
+        }
+    }
+    
+    init(storageKey: LocalStorageKey<QueryAnchor>, in localStorage: LocalStorage) {
+        get = { try localStorage.load(storageKey) ?? QueryAnchor() }
+        set = { try localStorage.store($0, for: storageKey) }
+    }
+    
+    func update(_ newValue: QueryAnchor) throws {
+        if let oldValue = try? get(), oldValue == newValue {
+            return
+        }
+        try set(newValue)
+    }
+}

--- a/Sources/SpeziSensorKit/Sensor+WellKnown.swift
+++ b/Sources/SpeziSensorKit/Sensor+WellKnown.swift
@@ -1,0 +1,338 @@
+//
+// This source file is part of the SpeziSensorKit open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+public import CoreMotion
+@preconcurrency public import SensorKit
+public import SpeziFoundation
+
+
+extension SensorKit {
+    /// All ``Sensor``s currently known to the `SensorKit` module.
+    public static var allKnownSensors: [any AnySensor] {
+        Array {
+            Sensor.onWrist
+            Sensor.ambientLight
+            Sensor.ambientPressure
+            Sensor.heartRate
+            Sensor.pedometer
+            Sensor.wristTemperature
+            if #available(iOS 17.4, *) {
+                Sensor.ppg
+                Sensor.ecg
+            }
+            Sensor.visits
+            Sensor.deviceUsage
+            Sensor.accelerometer
+            Sensor.rotationRate
+            Sensor.messagesUsage
+            Sensor.phoneUsage
+            Sensor.keyboardMetrics
+            Sensor.siriSpeechMetrics
+            Sensor.telephonySpeechMetrics
+            Sensor.mediaEvents
+            Sensor.faceMetrics
+            Sensor.odometer
+        }
+    }
+}
+
+
+// MARK: Sensor Definitions
+
+extension Sensor where Sample == SRWristDetection {
+    /// A sensor that describes the watch’s position on the wrist.
+    @inlinable public static var onWrist: Sensor<SRWristDetection> {
+        Sensor(
+            srSensor: .onWristState,
+            displayName: "On-Wrist State",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRAmbientLightSample {
+    /// A sensor that provides ambient light information.
+    @inlinable public static var ambientLight: Sensor<SRAmbientLightSample> {
+        Sensor(
+            srSensor: .ambientLightSensor,
+            displayName: "Ambient Light",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == CMRecordedPressureData {
+    /// A sensor that provides pressure and temperature metrics.
+    @inlinable public static var ambientPressure: Sensor<CMRecordedPressureData> {
+        Sensor(
+            srSensor: .ambientPressure,
+            displayName: "Ambient Pressure",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .array
+        )
+    }
+}
+
+extension Sensor where Sample == CMHighFrequencyHeartRateData {
+    /// A sensor that provides the user’s heart rate data.
+    @inlinable public static var heartRate: Sensor<CMHighFrequencyHeartRateData> {
+        Sensor(
+            srSensor: .heartRate,
+            displayName: "Heart Rate",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == CMPedometerData {
+    /// A sensor that provides information about the user’s steps.
+    @inlinable public static var pedometer: Sensor<CMPedometerData> {
+        Sensor(
+            srSensor: .pedometerData,
+            displayName: "Pedometer",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRWristTemperatureSession {
+    /// A sensor that provides wrist temperature while the user sleeps.
+    @inlinable public static var wristTemperature: Sensor<SRWristTemperatureSession> {
+        Sensor(
+            srSensor: .wristTemperature,
+            displayName: "Wrist Temperature",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+@available(iOS 17.4, *)
+extension Sensor where Sample == SRPhotoplethysmogramSample {
+    /// A sensor that streams sample PPG sensor data.
+    @inlinable public static var ppg: Sensor<SRPhotoplethysmogramSample> {
+        Sensor(
+            srSensor: .photoplethysmogram,
+            displayName: "PPG",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .array
+        )
+    }
+}
+
+@available(iOS 17.4, *)
+extension Sensor where Sample == SRElectrocardiogramSample {
+    /// A sensor that streams sample ECG sensor data.
+    @inlinable public static var ecg: Sensor<SRElectrocardiogramSample> {
+        Sensor(
+            srSensor: .electrocardiogram,
+            displayName: "ECG",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .array
+        )
+    }
+}
+
+extension Sensor where Sample == SRVisit {
+    /// A sensor that provides information about frequently visited locations.
+    @inlinable public static var visits: Sensor<SRVisit> {
+        Sensor(
+            srSensor: .visits,
+            displayName: "Visits",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRDeviceUsageReport {
+    /// A sensor that provides information about device usage.
+    @inlinable public static var deviceUsage: Sensor<SRDeviceUsageReport> {
+        Sensor(
+            srSensor: .deviceUsageReport,
+            displayName: "Device Usage Report",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == CMRecordedAccelerometerData {
+    /// A sensor that provides acceleration motion data.
+    @inlinable public static var accelerometer: Sensor<CMRecordedAccelerometerData> {
+        Sensor(
+            srSensor: .accelerometer,
+            displayName: "Accelerometer",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .array
+        )
+    }
+}
+
+extension Sensor where Sample == CMRecordedRotationRateData {
+    /// A sensor that provides rotation motion data.
+    @inlinable public static var rotationRate: Sensor<CMRecordedRotationRateData> {
+        Sensor(
+            srSensor: .rotationRate,
+            displayName: "Rotation Rate",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .array
+        )
+    }
+}
+
+extension Sensor where Sample == SRMessagesUsageReport {
+    /// A sensor that provides information about use of the Messages app.
+    @inlinable public static var messagesUsage: Sensor<SRMessagesUsageReport> {
+        Sensor(
+            srSensor: .messagesUsageReport,
+            displayName: "Messages Usage",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRPhoneUsageReport {
+    /// A sensor that reports the amount of time that the user is on phone calls.
+    @inlinable public static var phoneUsage: Sensor<SRPhoneUsageReport> {
+        Sensor(
+            srSensor: .phoneUsageReport,
+            displayName: "Phone Usage",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRKeyboardMetrics {
+    /// A sensor that provides information about keyboard usage.
+    @inlinable public static var keyboardMetrics: Sensor<SRKeyboardMetrics> {
+        Sensor(
+            srSensor: .keyboardMetrics,
+            displayName: "Keyboard Metrics",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRSpeechMetrics {
+    /// A sensor that provides data describing a user’s speech to Siri.
+    @inlinable public static var siriSpeechMetrics: Sensor<SRSpeechMetrics> {
+        Sensor(
+            srSensor: .siriSpeechMetrics,
+            displayName: "Speech Metrics",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRSpeechMetrics {
+    /// A sensor that provides data describing speech during phone calls.
+    @inlinable public static var telephonySpeechMetrics: Sensor<SRSpeechMetrics> {
+        Sensor(
+            srSensor: .telephonySpeechMetrics,
+            displayName: "Telephony Speech Metrics",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRMediaEvent {
+    /// A sensor that provides information about interactions with media, such as images and videos, in messaging apps.
+    @inlinable public static var mediaEvents: Sensor<SRMediaEvent> {
+        Sensor(
+            srSensor: .mediaEvents,
+            displayName: "Media Events",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == SRFaceMetrics {
+    /// A sensor that provides data describing a user’s face.
+    @inlinable public static var faceMetrics: Sensor<SRFaceMetrics> {
+        Sensor(
+            srSensor: .faceMetrics,
+            displayName: "Face Metrics",
+            dataQuarantineDuration: .days(7),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+extension Sensor where Sample == CMOdometerData {
+    /// A sensor that provides information about speed and slope.
+    @inlinable public static var odometer: Sensor<CMOdometerData> {
+        Sensor(
+            srSensor: .odometer,
+            displayName: "Odometer (Speed and Slope)",
+            dataQuarantineDuration: .hours(24),
+            sensorKitFetchReturnType: .object
+        )
+    }
+}
+
+
+// MARK: Utils
+
+extension SRSensor {
+    var sensor: (any AnySensor)? {
+        if self == .ambientLightSensor {
+            Sensor.ambientLight
+        } else if self == .accelerometer {
+            Sensor.accelerometer
+        } else if self == .rotationRate {
+            Sensor.rotationRate
+        } else if self == .visits {
+            Sensor.visits
+        } else if self == .pedometerData {
+            Sensor.pedometer
+        } else if self == .deviceUsageReport {
+            Sensor.deviceUsage
+        } else if self == .messagesUsageReport {
+            Sensor.messagesUsage
+        } else if self == .phoneUsageReport {
+            Sensor.phoneUsage
+        } else if self == .onWristState {
+            Sensor.onWrist
+        } else if self == .keyboardMetrics {
+            Sensor.keyboardMetrics
+        } else if self == .siriSpeechMetrics {
+            Sensor.siriSpeechMetrics
+        } else if self == .telephonySpeechMetrics {
+            Sensor.telephonySpeechMetrics
+        } else if self == .ambientPressure {
+            Sensor.ambientPressure
+        } else if self == .mediaEvents {
+            Sensor.mediaEvents
+        } else if self == .wristTemperature {
+            Sensor.wristTemperature
+        } else if self == .heartRate {
+            Sensor.heartRate
+        } else if self == .faceMetrics {
+            Sensor.faceMetrics
+        } else if self == .odometer {
+            Sensor.odometer
+        } else if #available(iOS 17.4, *), self == .electrocardiogram {
+            Sensor.ecg
+        } else if #available(iOS 17.4, *), self == .photoplethysmogram {
+            Sensor.ppg
+        } else {
+            nil
+        }
+    }
+}

--- a/Sources/SpeziSensorKit/Sensor.swift
+++ b/Sources/SpeziSensorKit/Sensor.swift
@@ -6,19 +6,51 @@
 // SPDX-License-Identifier: MIT
 //
 
-public import CoreMotion
+// swiftlint:disable file_types_order
+
 @preconcurrency public import SensorKit
 public import SpeziFoundation
 
 
 /// A type-erased ``Sensor``
-public protocol AnySensor: Hashable, Sendable {
-    /// The underlying SensorKit `SRSensor`
+///
+/// - Important: The ``AnySensor`` protocol is public, but your application should not declare any new conformances to it; ``Sensor`` is the only type allowed to conform to ``AnySensor``.
+public protocol AnySensor<Sample>: Hashable, Identifiable, Sendable {
+    associatedtype Sample: AnyObject, Hashable
+    
+    /// The underlying SensorKit `SRSensor`.
     var srSensor: SRSensor { get }
-    /// The recommended display name
+    /// The recommended display name.
     var displayName: String { get }
     /// How long the system hold data in quarantine before it can be queried by applications.
     var dataQuarantineDuration: Duration { get }
+    /// The sensor's unique identifier.
+    var id: String { get }
+}
+
+extension AnySensor {
+    @inlinable public var id: String { // swiftlint:disable:this missing_docs
+        srSensor.rawValue
+    }
+    
+    var currentQuarantineBegin: Date {
+        .now.addingTimeInterval(-dataQuarantineDuration.timeInterval)
+    }
+    
+    var suggestedBatchSize: Duration {
+        switch self {
+        case Sensor.onWrist:
+            .days(1)
+        default:
+            .hours(2)
+        }
+    }
+}
+
+/// Compare two sensors, based on their identifiers
+@inlinable
+public func ~= (lhs: Sensor<some Any>, rhs: any AnySensor) -> Bool { // swiftlint:disable:this static_operator
+    lhs.id == rhs.id
 }
 
 
@@ -71,139 +103,13 @@ public struct Sensor<Sample: AnyObject & Hashable>: AnySensor {
         self.dataQuarantineDuration = dataQuarantineDuration
         self.sensorKitFetchReturnType = sensorKitFetchReturnType
     }
-}
-
-extension Sensor where Sample == SRWristDetection {
-    /// A sensor that describes the watch’s position on the wrist.
-    @inlinable public static var onWrist: Sensor<SRWristDetection> {
-        Sensor(
-            srSensor: .onWristState,
-            displayName: "On-Wrist State",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-extension Sensor where Sample == SRAmbientLightSample {
-    /// A sensor that provides ambient light information.
-    @inlinable public static var ambientLight: Sensor<SRAmbientLightSample> {
-        Sensor(
-            srSensor: .ambientLightSensor,
-            displayName: "Ambient Light",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-extension Sensor where Sample == CMRecordedPressureData {
-    /// A sensor that provides pressure and temperature metrics.
-    @inlinable public static var ambientPressure: Sensor<CMRecordedPressureData> {
-        Sensor(
-            srSensor: .ambientPressure,
-            displayName: "Ambient Pressure",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .array
-        )
-    }
-}
-
-extension Sensor where Sample == CMHighFrequencyHeartRateData {
-    /// A sensor that provides the user’s heart rate data.
-    @inlinable public static var heartRate: Sensor<CMHighFrequencyHeartRateData> {
-        Sensor(
-            srSensor: .heartRate,
-            displayName: "Heart Rate",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-extension Sensor where Sample == CMPedometerData {
-    /// A sensor that provides information about the user’s steps.
-    @inlinable public static var pedometer: Sensor<CMPedometerData> {
-        Sensor(
-            srSensor: .pedometerData,
-            displayName: "Pedometer",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-extension Sensor where Sample == SRWristTemperatureSession {
-    /// A sensor that provides wrist temperature while the user sleeps.
-    @inlinable public static var wristTemperature: Sensor<SRWristTemperatureSession> {
-        Sensor(
-            srSensor: .wristTemperature,
-            displayName: "Wrist Temperature",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-@available(iOS 17.4, *)
-extension Sensor where Sample == SRPhotoplethysmogramSample {
-    /// A sensor that streams sample PPG sensor data.
-    @inlinable public static var ppg: Sensor<SRPhotoplethysmogramSample> {
-        Sensor(
-            srSensor: .photoplethysmogram,
-            displayName: "PPG",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .array
-        )
-    }
-}
-
-@available(iOS 17.4, *)
-extension Sensor where Sample == SRElectrocardiogramSample {
-    /// A sensor that streams sample ECG sensor data.
-    @inlinable public static var ecg: Sensor<SRElectrocardiogramSample> {
-        Sensor(
-            srSensor: .electrocardiogram,
-            displayName: "ECG",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .array
-        )
-    }
-}
-
-extension Sensor where Sample == SRVisit {
-    /// A sensor that provides information about frequently visited locations.
-    @inlinable public static var visits: Sensor<SRVisit> {
-        Sensor(
-            srSensor: .visits,
-            displayName: "Visits",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-extension Sensor where Sample == SRDeviceUsageReport {
-    /// A sensor that provides information about device usage.
-    @inlinable public static var deviceUsage: Sensor<SRDeviceUsageReport> {
-        Sensor(
-            srSensor: .deviceUsageReport,
-            displayName: "Device Usage Report",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .object
-        )
-    }
-}
-
-
-extension Sensor where Sample == CMRecordedAccelerometerData {
-    /// A sensor that provides acceleration motion data.
-    @inlinable public static var accelerometer: Sensor<CMRecordedAccelerometerData> {
-        Sensor(
-            srSensor: .accelerometer,
-            displayName: "Accelerometer",
-            dataQuarantineDuration: .hours(24),
-            sensorKitFetchReturnType: .array
-        )
+    
+    /// Creates a ``Sensor`` from a type-erased ``AnySensor``.
+    ///
+    /// Since ``Sensor`` is the only type allowed to conform to ``AnySensor``, this is guaranteed to always succeed.
+    @inlinable
+    public init(_ typeErased: any AnySensor<Sample>) {
+        // SAFETY: `Sensor` is the only type allowed to conform to `AnySensor`.
+        self = typeErased as! Self // swiftlint:disable:this force_cast
     }
 }

--- a/Sources/SpeziSensorKit/SensorKit+Extensions.swift
+++ b/Sources/SpeziSensorKit/SensorKit+Extensions.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the SpeziSensorKit open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+public import SensorKit
+
+
+@available(iOS 17.4, *)
+extension SRElectrocardiogramData.Flags: @retroactive Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+}

--- a/Sources/SpeziSensorKit/SensorKit.swift
+++ b/Sources/SpeziSensorKit/SensorKit.swift
@@ -9,6 +9,8 @@
 public import Observation
 @_documentation(visibility: internal) @_exported @preconcurrency public import SensorKit
 public import Spezi
+import SpeziFoundation
+import SpeziLocalStorage
 
 
 /// Interact with SensorKit in your Spezi application
@@ -22,14 +24,18 @@ public import Spezi
 /// - ``authorizationStatus(for:)``
 /// - ``requestAccess(to:)``
 @Observable
-public final class SensorKit: Module, EnvironmentAccessible, Sendable {
+public final class SensorKit: Module, EnvironmentAccessible, @unchecked Sendable {
+    @ObservationIgnored @Dependency(LocalStorage.self) private var localStorage
+    
+    private let queryAnchorKeys = LocalStorageKeysStore<QueryAnchor> { sensor in
+        LocalStorageKey("edu.stanford.SpeziSensorKit.QueryAnchors.\(sensor.id)")
+    }
+    
+    /// Creates a new instance of the `SensorKit` module.
     public nonisolated init() {}
-}
-
-
-// MARK: Authorization
-
-extension SensorKit {
+    
+    // MARK: Authorization
+    
     /// Checks the  current authorization status of the specified sensor.
     public nonisolated func authorizationStatus(for sensor: Sensor<some Any>) -> SRAuthorizationStatus {
         SRSensorReader(sensor: sensor.srSensor).authorizationStatus
@@ -46,6 +52,97 @@ extension SensorKit {
                 return
             } else {
                 throw error
+            }
+        }
+    }
+    
+    
+    // MARK: Data Exporting
+    @available(iOS 18, *)
+    @SensorKitActor
+    public func fetchAnchored<Sample>(_ sensor: Sensor<Sample>) async throws -> some AsyncSequence<[FetchResult<Sample>], any Error> {
+        let anchor = await ManagedQueryAnchor(
+            storageKey: queryAnchorKeys.key(for: sensor),
+            in: localStorage
+        )
+        let reader = SensorReader(sensor)
+        let batched = try await reader.fetchBatched(anchor: anchor)
+        return batched
+    }
+    
+    /// Resets the query anchor for the specified sensor.
+    ///
+    /// This will cause subsequent calls to ``fetchAnchored(_:)`` to potentially re-fetch already-processed samples.
+    public func resetQueryAnchor(for sensor: Sensor<some Any>) throws {
+        try localStorage.delete(queryAnchorKeys.key(for: sensor))
+    }
+}
+
+
+// MARK: Utils
+
+extension SensorKit {
+    // Essentially just a thread-safe dictionary that keeps track of our `LocalStorageKey`s used by the `SampleTypeScopedLocalStorage`.
+    // The reason this exists is bc the LocalStorage API is intended to be used with long-lived LocalStorageKey objects, which doesn't easily
+    // work with the multi-key scoping approach we're using here.
+    // Were we not to use something like this for caching and re-using the keys, we'd need to create temporary `LocalStorageKey`s for
+    // every load/store operation, which would of course work but would also defeat the whole purpose of having the `LocalStorageKey`s
+    // be long-lived objects which are also used for e.g. locking / properly handling concurrent reads or writes.
+    final class LocalStorageKeysStore<Value>: Sendable {
+        private struct DictKey: Hashable {
+            let valueType: String
+            let sampleType: String
+            
+            init(sensor: some AnySensor<some Any>) {
+                // this is fine bc we're not using it as a stable identifier
+                // (the `valueType` key must only be valid&unique for the lifetime of the app)
+                self.valueType = String(reflecting: Value.self)
+                self.sampleType = sensor.id
+            }
+        }
+        
+        private let makeKey: @Sendable (any AnySensor) -> LocalStorageKey<Value>
+        private let lock = RWLock()
+        nonisolated(unsafe) private var keys: [DictKey: LocalStorageKey<Value>] = [:]
+        
+        init(makeKey: @escaping @Sendable (any AnySensor) -> LocalStorageKey<Value>) {
+            self.makeKey = makeKey
+        }
+        
+        func key(for sensor: some AnySensor<some Any>) -> LocalStorageKey<Value> {
+            lock.withWriteLock {
+                let dictKey = DictKey(sensor: sensor)
+                if let key = keys[dictKey] {
+                    return key
+                } else {
+                    let key = makeKey(sensor)
+                    keys[dictKey] = key
+                    return key
+                }
+            }
+        }
+    }
+    
+    
+    struct SensorScopedLocalStorage<Value: SendableMetatype>: Sendable {
+        private let localStorage: LocalStorage
+        private let localStorageKeysStore: LocalStorageKeysStore<Value>
+        
+        init(localStorage: LocalStorage, localStorageKeysStore: LocalStorageKeysStore<Value>) {
+            self.localStorage = localStorage
+            self.localStorageKeysStore = localStorageKeysStore
+        }
+        
+        private func storageKey(for sensor: Sensor<some Any>) -> LocalStorageKey<Value> {
+            localStorageKeysStore.key(for: sensor)
+        }
+        
+        subscript(sensor: Sensor<some Any>) -> Value? {
+            get {
+                try? localStorage.load(storageKey(for: sensor))
+            }
+            nonmutating set {
+                try? localStorage.store(newValue, for: storageKey(for: sensor))
             }
         }
     }

--- a/Sources/SpeziSensorKit/SensorReader.swift
+++ b/Sources/SpeziSensorKit/SensorReader.swift
@@ -133,15 +133,10 @@ public final class SensorReader<Sample: AnyObject & Hashable>: SensorReaderProto
     }
     
     @SensorKitActor
-    public func fetch(
-        from device: SRDevice? = nil, // swiftlint:disable:this function_default_parameter_at_end
-        timeRange: Range<Date>
-    ) async throws -> [SensorKit.FetchResult<Sample>] {
+    public func fetch(from device: SRDevice, timeRange: Range<Date>) async throws -> [SensorKit.FetchResult<Sample>] {
         try await lockedSensorKitOperation {
             let fetchRequest = SRFetchRequest()
-            if let device {
-                fetchRequest.device = device
-            }
+            fetchRequest.device = device
             fetchRequest.from = .fromCFAbsoluteTime(_cf: timeRange.lowerBound.timeIntervalSinceReferenceDate)
             fetchRequest.to = .fromCFAbsoluteTime(_cf: timeRange.upperBound.timeIntervalSinceReferenceDate)
             return try await withCheckedThrowingContinuation { continuation in


### PR DESCRIPTION
# tracked export API; additional sensor types

## :recycle: Current situation & Problem
SpeziSensorKit currently lacks the ability to perform a "give me all new samples since the last time i asked" query.

@PSchmiedmayer i've only made part of the new additions here public for now; we could in theory make more public but IMO we should defer that to a separate PR. what we have currently works well for the use case this PR aims to enable.


## :gear: Release Notes
- added an anchored-query API, which allows apps to fetch new data for a sensor, relative to the last time the API was invoked
- added support for several new sensor types


## :books: Documentation
yes


## :white_check_mark: Testing
no

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
